### PR TITLE
Implement the run and wait part of setup

### DIFF
--- a/examples/simple/e2e.yaml
+++ b/examples/simple/e2e.yaml
@@ -21,19 +21,16 @@ setup:
   manifests:
     - path: busybox1.yaml
       wait: 
-        - type: kube # wait type may not only kube. it can be `log` or `http` or else.
-          namespace: default
+        - namespace: default
           resource: pod/busybox1 
           for: condition=Ready
     - path: manifests,manifests2
       wait:
-        - type: kube
-          namespace: default
+        - namespace: default
           resource: pod
           label-selector: app=busybox2
           for: condition=Ready
-        - type: kube
-          namespace: default
+        - namespace: default
           resource: pod
           for: condition=Ready
   runs: # commands are serial within one code block and parallel between code blocks
@@ -41,16 +38,14 @@ setup:
         cp $TMPDIR/e2e-k8s.config ~/.kube/config
         kubectl create deployment nginx1 --image=nginx
       wait:
-        - type: kube
-          namespace: default
+        - namespace: default
           resource: deployment/nginx1
           for: condition=Available
     - command: |
         cp $TMPDIR/e2e-k8s.config ~/.kube/config
         kubectl create deployment nginx2 --image=nginx
       wait:
-        - type: kube
-          namespace: default
+        - namespace: default
           resource: deployment/nginx2
           for: condition=Available
   timeout: 600

--- a/examples/simple/e2e.yaml
+++ b/examples/simple/e2e.yaml
@@ -43,7 +43,8 @@ setup:
           for: condition=Available
     - command: |
         cp $TMPDIR/e2e-k8s.config ~/.kube/config
-        kubectl create deployment nginx2 --image=nginx
+        kubectl create deployment nginx2 \
+                                  --image=nginx
       wait:
         - namespace: default
           resource: deployment/nginx2

--- a/examples/simple/e2e.yaml
+++ b/examples/simple/e2e.yaml
@@ -21,18 +21,38 @@ setup:
   manifests:
     - path: busybox1.yaml
       wait: 
-        - namespace: default
+        - type: kube # wait type may not only kube. it can be `log` or `http` or else.
+          namespace: default
           resource: pod/busybox1 
           for: condition=Ready
     - path: manifests,manifests2
       wait:
-        - namespace: default
+        - type: kube
+          namespace: default
           resource: pod
           label-selector: app=busybox2
           for: condition=Ready
-        - namespace: default
+        - type: kube
+          namespace: default
           resource: pod
           for: condition=Ready
+  runs: # commands are serial within one code block and parallel between code blocks
+    - command: | # it can be a shell script or anything executable
+        cp $TMPDIR/e2e-k8s.config ~/.kube/config
+        kubectl create deployment nginx1 --image=nginx
+      wait:
+        - type: kube
+          namespace: default
+          resource: deployment/nginx1
+          for: condition=Available
+    - command: |
+        cp $TMPDIR/e2e-k8s.config ~/.kube/config
+        kubectl create deployment nginx2 --image=nginx
+      wait:
+        - type: kube
+          namespace: default
+          resource: deployment/nginx2
+          for: condition=Available
   timeout: 600
 
 verify:

--- a/internal/components/setup/common.go
+++ b/internal/components/setup/common.go
@@ -1,0 +1,124 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package setup
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/apache/skywalking-infra-e2e/internal/constant"
+
+	"github.com/apache/skywalking-infra-e2e/internal/config"
+	"github.com/apache/skywalking-infra-e2e/internal/logger"
+	"github.com/apache/skywalking-infra-e2e/internal/util"
+)
+
+// RunCommandsAndWait Concurrently run commands and wait for conditions.
+func RunCommandsAndWait(runs []config.Run, timeout time.Duration) error {
+	waitSet := util.NewWaitSet(timeout)
+
+	for idx := range runs {
+		run := runs[idx]
+		command := run.Command
+		if len(command) < 1 {
+			continue
+		}
+
+		commands := strings.Split(command, "\n")
+
+		waitSet.WaitGroup.Add(1)
+		go executeCommandsAndWait(commands, run.Waits, waitSet)
+	}
+
+	go func() {
+		waitSet.WaitGroup.Wait()
+		close(waitSet.FinishChan)
+	}()
+
+	select {
+	case <-waitSet.FinishChan:
+		logger.Log.Infof("all commands executed successfully")
+	case err := <-waitSet.ErrChan:
+		logger.Log.Errorf("execute command error")
+		return err
+	case <-time.After(waitSet.Timeout):
+		return fmt.Errorf("wait for commands run timeout after %d seconds", int(timeout.Seconds()))
+	}
+
+	return nil
+}
+
+func executeCommandsAndWait(commands []string, waits []config.Wait, waitSet *util.WaitSet) {
+	defer waitSet.WaitGroup.Done()
+
+	// executes commands
+	for _, command := range commands {
+		if len(command) < 1 {
+			continue
+		}
+
+		logger.Log.Infof("executing command %s", command)
+		result, err := util.ExecuteCommand(command)
+		if err != nil {
+			err = fmt.Errorf("command: [%s] runs error: %s", command, err)
+			waitSet.ErrChan <- err
+		}
+		logger.Log.Infof("executed command %s, result: %s", command, result)
+	}
+
+	// waits for conditions meet
+	for idx := range waits {
+		wait := waits[idx]
+		logger.Log.Infof("waiting for %+v", wait)
+
+		if wait.Type == constant.KubeWaitType {
+			kubeConfigYaml, err := ioutil.ReadFile(kubeConfigPath)
+			if err != nil {
+				err = fmt.Errorf("read kube config failed: %s", err)
+				waitSet.ErrChan <- err
+			}
+
+			options, err := getWaitOptions(kubeConfigYaml, &wait)
+			if err != nil {
+				err = fmt.Errorf("commands: [%s] get wait options error: %s", commands, err)
+				waitSet.ErrChan <- err
+			}
+
+			err = options.RunWait()
+			if err != nil {
+				err = fmt.Errorf("commands: [%s] waits error: %s", commands, err)
+				waitSet.ErrChan <- err
+				return
+			}
+			logger.Log.Infof("wait %+v condition met", wait)
+		} else {
+			err := fmt.Errorf("wait type %s not implement yet", wait.Type)
+			waitSet.ErrChan <- err
+		}
+	}
+}
+
+// NewTimeout calculates new timeout since timeBefore.
+func NewTimeout(timeBefore time.Time, timeout time.Duration) time.Duration {
+	elapsed := time.Since(timeBefore)
+	newTimeout := timeout - elapsed
+	return newTimeout
+}

--- a/internal/components/setup/common.go
+++ b/internal/components/setup/common.go
@@ -40,7 +40,7 @@ func RunCommandsAndWait(runs []config.Run, timeout time.Duration) error {
 			continue
 		}
 
-		commands := strings.Split(command, "\n")
+		commands := parseRunCommand(command)
 
 		waitSet.WaitGroup.Add(1)
 		go executeCommandsAndWait(commands, run.Waits, waitSet)
@@ -62,6 +62,13 @@ func RunCommandsAndWait(runs []config.Run, timeout time.Duration) error {
 	}
 
 	return nil
+}
+
+// parseRunCommand parses command lines to individual commands.
+func parseRunCommand(command string) (commands []string) {
+	replacedCommand := strings.ReplaceAll(command, "\\\n", " ")
+	commands = strings.Split(replacedCommand, "\n")
+	return commands
 }
 
 func executeCommandsAndWait(commands []string, waits []config.Wait, waitSet *util.WaitSet) {

--- a/internal/components/setup/common.go
+++ b/internal/components/setup/common.go
@@ -106,7 +106,6 @@ func executeCommandsAndWait(commands []string, waits []config.Wait, waitSet *uti
 			return
 		}
 		logger.Log.Infof("wait %+v condition met", wait)
-
 	}
 }
 

--- a/internal/components/setup/common.go
+++ b/internal/components/setup/common.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apache/skywalking-infra-e2e/internal/constant"
-
 	"github.com/apache/skywalking-infra-e2e/internal/config"
 	"github.com/apache/skywalking-infra-e2e/internal/logger"
 	"github.com/apache/skywalking-infra-e2e/internal/util"
@@ -89,30 +87,26 @@ func executeCommandsAndWait(commands []string, waits []config.Wait, waitSet *uti
 		wait := waits[idx]
 		logger.Log.Infof("waiting for %+v", wait)
 
-		if wait.Type == constant.KubeWaitType {
-			kubeConfigYaml, err := ioutil.ReadFile(kubeConfigPath)
-			if err != nil {
-				err = fmt.Errorf("read kube config failed: %s", err)
-				waitSet.ErrChan <- err
-			}
-
-			options, err := getWaitOptions(kubeConfigYaml, &wait)
-			if err != nil {
-				err = fmt.Errorf("commands: [%s] get wait options error: %s", commands, err)
-				waitSet.ErrChan <- err
-			}
-
-			err = options.RunWait()
-			if err != nil {
-				err = fmt.Errorf("commands: [%s] waits error: %s", commands, err)
-				waitSet.ErrChan <- err
-				return
-			}
-			logger.Log.Infof("wait %+v condition met", wait)
-		} else {
-			err := fmt.Errorf("wait type %s not implement yet", wait.Type)
+		kubeConfigYaml, err := ioutil.ReadFile(kubeConfigPath)
+		if err != nil {
+			err = fmt.Errorf("read kube config failed: %s", err)
 			waitSet.ErrChan <- err
 		}
+
+		options, err := getWaitOptions(kubeConfigYaml, &wait)
+		if err != nil {
+			err = fmt.Errorf("commands: [%s] get wait options error: %s", commands, err)
+			waitSet.ErrChan <- err
+		}
+
+		err = options.RunWait()
+		if err != nil {
+			err = fmt.Errorf("commands: [%s] waits error: %s", commands, err)
+			waitSet.ErrChan <- err
+			return
+		}
+		logger.Log.Infof("wait %+v condition met", wait)
+
 	}
 }
 

--- a/internal/components/setup/kind.go
+++ b/internal/components/setup/kind.go
@@ -150,18 +150,13 @@ func createManifestsAndWait(c *kubernetes.Clientset, dc dynamic.Interface, manif
 			wait := waits[idx]
 			logger.Log.Infof("waiting for %+v", wait)
 
-			if wait.Type == constant.KubeWaitType {
-				options, err := getWaitOptions(kubeConfigYaml, &wait)
-				if err != nil {
-					return err
-				}
-
-				waitSet.WaitGroup.Add(1)
-				go concurrentlyWait(&wait, options, waitSet)
-			} else {
-				err := fmt.Errorf("wait type %s not implement yet", wait.Type)
+			options, err := getWaitOptions(kubeConfigYaml, &wait)
+			if err != nil {
 				return err
 			}
+
+			waitSet.WaitGroup.Add(1)
+			go concurrentlyWait(&wait, options, waitSet)
 		}
 	}
 

--- a/internal/config/e2eConfig.go
+++ b/internal/config/e2eConfig.go
@@ -52,10 +52,6 @@ type Run struct {
 	Waits   []Wait `yaml:"wait"`
 }
 
-func (r Run) GetRunCommand() string {
-	return r.Command
-}
-
 type Wait struct {
 	Namespace     string `yaml:"namespace"`
 	Resource      string `yaml:"resource"`

--- a/internal/config/e2eConfig.go
+++ b/internal/config/e2eConfig.go
@@ -57,7 +57,6 @@ func (r Run) GetRunCommand() string {
 }
 
 type Wait struct {
-	Type          string `yaml:"type"`
 	Namespace     string `yaml:"namespace"`
 	Resource      string `yaml:"resource"`
 	LabelSelector string `yaml:"label-selector"`

--- a/internal/config/e2eConfig.go
+++ b/internal/config/e2eConfig.go
@@ -30,9 +30,8 @@ type Setup struct {
 	Env       string     `yaml:"env"`
 	File      string     `yaml:"file"`
 	Manifests []Manifest `yaml:"manifests"`
-	// Run is not supported yet
-	Run     []Run `yaml:"run"`
-	Timeout int   `yaml:"timeout"`
+	Runs      []Run      `yaml:"runs"`
+	Timeout   int        `yaml:"timeout"`
 }
 
 func (s *Setup) GetFile() string {
@@ -53,7 +52,12 @@ type Run struct {
 	Waits   []Wait `yaml:"wait"`
 }
 
+func (r Run) GetRunCommand() string {
+	return r.Command
+}
+
 type Wait struct {
+	Type          string `yaml:"type"`
 	Namespace     string `yaml:"namespace"`
 	Resource      string `yaml:"resource"`
 	LabelSelector string `yaml:"label-selector"`

--- a/internal/config/globalConfig.go
+++ b/internal/config/globalConfig.go
@@ -28,7 +28,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// GlobalE2EConfig store E2EConfig which can be used globally.
+// GlobalE2EConfig stores E2EConfig which can be used globally.
 type GlobalE2EConfig struct {
 	Error     error
 	E2EConfig E2EConfig

--- a/internal/constant/kind.go
+++ b/internal/constant/kind.go
@@ -28,7 +28,6 @@ const (
 	Kind                     = "kind"
 	KindCommand              = "kind"
 	KindClusterDefaultName   = "kind"
-	KubeWaitType             = "kube"
 	E2EDefaultFile           = "e2e.yaml"
 	K8sClusterConfigFileName = "e2e-k8s.config"
 	DefaultWaitTimeout       = 600 * time.Second

--- a/internal/constant/kind.go
+++ b/internal/constant/kind.go
@@ -28,6 +28,7 @@ const (
 	Kind                     = "kind"
 	KindCommand              = "kind"
 	KindClusterDefaultName   = "kind"
+	KubeWaitType             = "kube"
 	E2EDefaultFile           = "e2e.yaml"
 	K8sClusterConfigFileName = "e2e-k8s.config"
 	DefaultWaitTimeout       = 600 * time.Second


### PR DESCRIPTION
Implement the run and wait part of setup.
`setup.runs` part  can have multi run blocks. Commands running serially within one block and parallelly between blocks.

I will add some docs afterwards about setup part.
