### PR TITLE
Fix only gt compare function working

### DIFF
--- a/third-party/go/template/funcs.go
+++ b/third-party/go/template/funcs.go
@@ -577,7 +577,11 @@ func le(arg1, arg2 reflect.Value) (interface{}, error) {
 	if lessThan || err != nil {
 		return arg1, err
 	}
-	return eq(arg1, arg2)
+	equal, err := eq(arg1, arg2)
+	if equal || err != nil {
+		return arg1, err
+	}
+	return fmt.Sprintf("<wanted le %v, but was %v>", value2string(arg2), value2string(arg1)), nil
 }
 
 // gt evaluates the comparison a > b.

--- a/third-party/go/template/funcs.go
+++ b/third-party/go/template/funcs.go
@@ -517,7 +517,7 @@ func ne(arg1, arg2 reflect.Value) (bool, error) {
 }
 
 // lt evaluates the comparison a < b.
-func lt(arg1, arg2 reflect.Value) (bool, error) {
+func lt2bool(arg1, arg2 reflect.Value) (bool, error) {
 	arg1 = indirectInterface(arg1)
 	k1, err := basicKind(arg1)
 	if err != nil {
@@ -558,12 +558,24 @@ func lt(arg1, arg2 reflect.Value) (bool, error) {
 	return truth, nil
 }
 
+// lt evaluates the comparison a < b.
+func lt(arg1, arg2 reflect.Value) (interface{}, error) {
+	lessThan, err := lt2bool(arg1, arg2)
+	if err != nil {
+		return nil, err
+	}
+	if lessThan {
+		return arg1, nil
+	}
+	return fmt.Sprintf("<wanted lt %v, but was %v>", value2string(arg2), value2string(arg1)), nil
+}
+
 // le evaluates the comparison <= b.
-func le(arg1, arg2 reflect.Value) (bool, error) {
+func le(arg1, arg2 reflect.Value) (interface{}, error) {
 	// <= is < or ==.
-	lessThan, err := lt(arg1, arg2)
+	lessThan, err := lt2bool(arg1, arg2)
 	if lessThan || err != nil {
-		return lessThan, err
+		return arg1, err
 	}
 	return eq(arg1, arg2)
 }
@@ -571,24 +583,53 @@ func le(arg1, arg2 reflect.Value) (bool, error) {
 // gt evaluates the comparison a > b.
 func gt(arg1, arg2 reflect.Value) (interface{}, error) {
 	// > is the inverse of <=.
-	lessOrEqual, err := le(arg1, arg2)
+	less, err := lt2bool(arg1, arg2)
 	if err != nil {
 		return nil, err
 	}
-	if !lessOrEqual {
-		return arg1, nil
+	if !less {
+		equal, err := eq(arg1, arg2)
+		if err != nil {
+			return nil, err
+		}
+		if !equal {
+			return arg1, nil
+		}
 	}
-	return fmt.Sprintf("<wanted gt %v, but was %v>", arg2, arg1), nil
+	return fmt.Sprintf("<wanted gt %v, but was %v>", value2string(arg2), value2string(arg1)), nil
 }
 
 // ge evaluates the comparison a >= b.
-func ge(arg1, arg2 reflect.Value) (bool, error) {
+func ge(arg1, arg2 reflect.Value) (interface{}, error) {
 	// >= is the inverse of <.
-	lessThan, err := lt(arg1, arg2)
+	lessThan, err := lt2bool(arg1, arg2)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return !lessThan, nil
+	if !lessThan {
+		return arg1, nil
+	}
+	return fmt.Sprintf("<wanted ge %v, but was %v>", value2string(arg2), value2string(arg1)), nil
+}
+
+func value2string(value reflect.Value) string {
+	k1, _ := basicKind(value)
+	switch k1 {
+	case boolKind:
+		return fmt.Sprintf("%t", value.Bool())
+	case complexKind:
+		return fmt.Sprintf("%v", value.Complex())
+	case floatKind:
+		return fmt.Sprintf("%f", value.Float())
+	case intKind:
+		return fmt.Sprintf("%d", value.Int())
+	case stringKind:
+		return fmt.Sprintf("%s", value.String())
+	case uintKind:
+		return fmt.Sprintf("%d", value.Uint())
+	default:
+		return value.String()
+	}
 }
 
 // HTML escaping.

--- a/third-party/go/template/funcs_test.go
+++ b/third-party/go/template/funcs_test.go
@@ -1,0 +1,56 @@
+package template
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		arg0           int
+		arg1           int
+		compareResults []bool
+	}{
+		{
+			5, 10,
+			[]bool{5 < 10, 5 <= 10, 5 >= 10, 5 > 10},
+		},
+		{
+			10, 10,
+			[]bool{10 < 10, 10 <= 10, 10 >= 10, 10 > 10},
+		},
+		{
+			15, 10,
+			[]bool{15 < 10, 15 <= 10, 15 >= 10, 15 > 10},
+		},
+	}
+
+	type compare func(ar0, ar1 reflect.Value) (interface{}, error)
+	compareNames := []string{
+		"lt", "le", "ge", "gt",
+	}
+	compares := []compare{
+		lt, le, ge, gt,
+	}
+
+	for _, data := range tests {
+		for inx, comp := range compares {
+			res, err := comp(reflect.ValueOf(data.arg0), reflect.ValueOf(data.arg1))
+			validateSuccess := false
+			// need be true
+			if err == nil {
+				if data.compareResults[inx] {
+					validateSuccess = data.arg0 == int(res.(reflect.Value).Int())
+				} else {
+					validateSuccess = reflect.TypeOf(res).Kind() == reflect.String
+				}
+			} else {
+				res = err
+			}
+
+			if !validateSuccess {
+				t.Errorf("execute error, %d %s %d error: %v", data.arg0, compareNames[inx], data.arg1, res)
+			}
+		}
+	}
+}


### PR DESCRIPTION
In the previous version, only `gt` can return real values, but like `ge` or other comparison functions cannot return real values, they are still `boolean` values. In the document, I will create another PR to write.
previous version (value = 10):
```
{{gt .value 0}}  -> 10
{{ge .value 10}} -> true
```
update version (version = 10):
```
{{gt .value 0}}  -> 10
{{ge .value 10}} -> 10
```