### PR TITLE
Install yq to convert yaml content for e2e testing

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,5 +41,12 @@ runs:
         make build && mv bin/swctl-*-linux-amd64 ../bin/swctl
     - shell: bash
       run: |
+        cd /tmp/skywalking-infra-e2e
+        mkdir yq && cd yq
+        wget -O yq.tar.gz https://github.com/mikefarah/yq/archive/v4.11.1.tar.gz
+        tar -zxf yq.tar.gz --strip=1
+        go install && go build -ldflags -s && mv yq ../bin/yq
+    - shell: bash
+      run: |
         export PATH="$PATH:/tmp/skywalking-infra-e2e/bin"
         e2e run -c "${{ inputs.e2e-file }}"


### PR DESCRIPTION
When I using `e2e` to verify metrics data, I see the `skywalking-cli` return the metrics in YAML object format. It could not verify in the `infra-e2e`, so I need to install `yq` to convert the result.
```
swctl --display yaml  metrics linear ...
```
current results like this format:
```
2021-07-21 1009: 100
```

when using `yq`, I could using `yq e 'to_entries' -` to change the format to `list`:
```
- key: 2021-07-21 1009
  value: 100
```