### PR TITLE
Improve features for verify

### DIFF
--- a/commands/verify/verify.go
+++ b/commands/verify/verify.go
@@ -78,7 +78,7 @@ func verifySingleCase(expectedFile, actualFile, query string) error {
 		if me, ok := err.(*verifier.MismatchError); ok {
 			return fmt.Errorf("failed to verify the output: %s, error: %v", sourceName, me.Error())
 		}
-		return fmt.Errorf("failed to verify the output: %s", sourceName)
+		return fmt.Errorf("failed to verify the output: %s, error: %v", sourceName, err)
 	}
 	logger.Log.Infof("verified the output: %s\n", sourceName)
 	return nil

--- a/internal/components/verifier/verifier_test.go
+++ b/internal/components/verifier/verifier_test.go
@@ -139,6 +139,62 @@ metrics:
 			},
 			wantErr: true,
 		},
+		{
+			name: "multiple level attribute and contains greater and equals 2",
+			args: args{
+				actualData: `
+metrics:
+  key:
+  - name: business-zone::projectA
+    id: YnVzaW5lc3Mtem9uZTo6cHJvamVjdEE=.1
+    value: 1
+  - name: system::load balancer1
+    id: c3lzdGVtOjpsb2FkIGJhbGFuY2VyMQ==.1
+    value: 0
+  - name: system::load balancer2
+    id: WW91cl9BcHBsaWNhdGlvbk5hbWU=.1
+    value: 2
+`,
+				expectedTemplate: `
+metrics:
+  key:
+  {{- contains .metrics.key }}
+    - name: {{ notEmpty .name }}
+      id: {{ notEmpty .id }}
+      value: {{ ge .value 2 }}
+  {{- end }}
+`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple level attribute and contains greater 2",
+			args: args{
+				actualData: `
+metrics:
+  key:
+  - name: business-zone::projectA
+    id: YnVzaW5lc3Mtem9uZTo6cHJvamVjdEE=.1
+    value: 1
+  - name: system::load balancer1
+    id: c3lzdGVtOjpsb2FkIGJhbGFuY2VyMQ==.1
+    value: 0
+  - name: system::load balancer2
+    id: WW91cl9BcHBsaWNhdGlvbk5hbWU=.1
+    value: 2
+`,
+				expectedTemplate: `
+metrics:
+  key:
+  {{- contains .metrics.key }}
+    - name: {{ notEmpty .name }}
+      id: {{ notEmpty .id }}
+      value: {{ gt .value 2 }}
+  {{- end }}
+`,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/third-party/go/template/exec.go
+++ b/third-party/go/template/exec.go
@@ -441,52 +441,37 @@ func (s *state) walkContains(dot reflect.Value, r *parse.ContainsNode) {
 		// matched stores the matched pair of indices <expected index>: <actual index>
 		matched := make(map[int]int)
 		output := make([]interface{}, val.Len())
-		// last match with condition index
-		lastMatchInx := make(map[int]int)
 		for i := 0; i < val.Len(); i++ {
 			expectedArr := oneIteration(reflect.ValueOf(i), val.Index(i))
 			// expectedSize is the number of elements that the actual array should contain.
 			expectedSize = len(expectedArr)
 			actual, _ := printableValue(val.Index(i))
 			for j, expected := range expectedArr {
-				lastMatchInx[i] = j
 				if fmt.Sprint(actual) == fmt.Sprint(expected) {
 					matched[j] = i
 					output[i] = actual
-					break
 				} else {
 					output[i] = expected
 				}
 			}
 		}
 
-		// split condition array to ListNodes
-		matchParseList := make(map[int]*parse.ListNode)
-		// using first list token index, encase nested list
-		listIndex := strings.Index(strings.TrimPrefix(r.List.Nodes[0].String(), "\n"), "-")
-		for _, node := range r.List.Nodes {
-			if string([]rune(strings.TrimPrefix(node.String(), "\n"))[listIndex]) == "-" {
-				listNode := r.List.CopyList()
-				listNode.Nodes = []parse.Node{}
-				matchParseList[len(matchParseList)] = listNode
-			}
-			curNode := matchParseList[len(matchParseList)-1]
-			curNode.Nodes = append(curNode.Nodes, node)
+		var addRootIndent = func(b []byte, n int) []byte {
+			prefix := append([]byte("\n"), bytes.Repeat([]byte(" "), n)...)
+			b = append(prefix[1:], b...) // Indent first line
+			return bytes.ReplaceAll(b, []byte("\n"), prefix)
+		}
+		var marshal []byte
+		if len(matched) == expectedSize {
+			value, _ := printableValue(val)
+			marshal, _ = yaml.Marshal(value)
+		} else {
+			marshal, _ = yaml.Marshal(output)
 		}
 
-		var list []interface{}
-		if len(matched) == expectedSize {
-			valList, _ := printableValue(val)
-			list = valList.([]interface{})
-		} else {
-			list = output
-		}
-		// use matches condition to write
-		for inx, d := range list {
-			data := reflect.ValueOf(d)
-			s.walk(data, matchParseList[lastMatchInx[inx]])
-			s.pop(mark)
-		}
+		listTokenIndex := strings.Index(strings.TrimPrefix(r.List.Nodes[0].String(), "\n"), "-")
+		marshal = addRootIndent(marshal, listTokenIndex)
+		s.wr.Write(append([]byte("\n"), marshal...))
 		return
 	case reflect.Map:
 		if val.Len() == 0 {


### PR DESCRIPTION
1. show the error message when read expect file error or render template error
2. Let `contains` condition support multiple levels attributes.
    here is an example: 
     ```
     a: 
       b:
       {{ contains .test }}
          - data: {{ gt .d1 0 }}
          - data: {{ ge .d2 0 }}
       {{- end }}
     ```
     current result:
     ```
     a:
        b:
     - data: 1
     - data: 2
     ```
     after improve:
     ```
     a:
        b:
           - data: 1
           - data: 2
     ```