### PR TITLE
Use native executable by default and move Docker GHA to another path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,23 +16,6 @@
 # under the License.
 #
 
-FROM golang:1.16 AS swctl
-
-ARG COMMIT_HASH=master
-ARG CLI_CODE=${COMMIT_HASH}.tar.gz
-ARG CLI_CODE_URL=https://github.com/apache/skywalking-cli/archive/${CLI_CODE}
-
-ENV CGO_ENABLED=0
-ENV GO111MODULE=on
-
-WORKDIR /cli
-
-ADD ${CLI_CODE_URL} .
-RUN tar -xf ${CLI_CODE} --strip 1
-RUN rm ${CLI_CODE}
-
-RUN VERSION=ci make linux && mv bin/swctl-ci-linux-amd64 /usr/local/bin/swctl
-
 FROM golang:1.16 AS build
 
 WORKDIR /e2e
@@ -46,7 +29,6 @@ FROM golang:1.16 AS bin
 RUN apt update; \
     apt install -y docker-compose
 
-COPY --from=swctl /usr/local/bin/swctl /usr/local/bin/swctl
 COPY --from=build /e2e/bin/linux/e2e /usr/local/bin/e2e
 
 # Add common tools, copy from prebuilt Docker image whenever possible.

--- a/docker/action.yaml
+++ b/docker/action.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: SkyWalking Infra E2E
+name: SkyWalking Infra E2E Dockerized
 description: End-to-End Tesing framework that help to set up, verify E2E tests.
 author: Apache SkyWalking
 inputs:
@@ -26,9 +26,11 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: |
-        make -C $GITHUB_ACTION_PATH docker
-        docker run -v $(pwd):/tmp -w /tmp --entrypoint=sh docker.io/apache/e2e:latest -c "cp /usr/local/bin/e2e /tmp/e2e"
-        install ./e2e /usr/local/bin
+      run: make -C $GITHUB_ACTION_PATH docker
     - shell: bash
-      run: e2e run -c "${{ inputs.e2e-file }}"
+      run: |
+        printenv > env.list
+        docker run -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+                   -v /var/run/docker.sock:/var/run/docker.sock \
+                   -w $GITHUB_WORKSPACE --env-file env.list \
+                   docker.io/apache/e2e:latest run -c "${{ inputs.e2e-file }}"


### PR DESCRIPTION
As Docker-based GHA is not testable locally and there are a bunch of known and unknown issues due to Docker in Docker limitations, we should not use Docker GHA by default. 

This PR uses native executable binary `e2e` and move Docker-based GHA to subpath `docker`, if @mrproliu you want to test Docker-based GHA, please use `apache/skywalking-infra-e2e/docker@main`