### PR TITLE
Using including file path as included cases' `expect/actual` base path

### DIFF
--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -32,6 +32,16 @@ var (
 
 // ResolveAbs resolves the relative path (relative to CfgFile) to an absolute file path.
 func ResolveAbs(p string) string {
+	abs, err := filepath.Abs(CfgFile)
+	if err != nil {
+		logger.Log.Warnf("failed to resolve the absolute file path of %v\n", CfgFile)
+		return p
+	}
+	return ResolveAbsWithBase(p, abs)
+}
+
+// ResolveAbsWithBase resolves the relative path (relative to appoint file path) to an absolute file path.
+func ResolveAbsWithBase(p, baseFile string) string {
 	if p == "" {
 		return p
 	}
@@ -40,11 +50,5 @@ func ResolveAbs(p string) string {
 		return p
 	}
 
-	abs, err := filepath.Abs(CfgFile)
-	if err != nil {
-		logger.Log.Warnf("failed to resolve the absolute file path of %v\n", CfgFile)
-		return p
-	}
-
-	return filepath.Join(filepath.Dir(abs), p)
+	return filepath.Join(filepath.Dir(baseFile), p)
 }


### PR DESCRIPTION
There before, we use the `e2e.yaml` file path as all file base paths. But after using the reuse file, their cases base path should change to the reuse file base path. 