### PR TITLE
Let reuse file support environment to replace variable

### DIFF
--- a/docs/en/setup/Configuration-File.md
+++ b/docs/en/setup/Configuration-File.md
@@ -116,6 +116,8 @@ verify:
       expected: path/to/expected.yaml   # excepted content file path
     - includes:      # including cases
         - path/to/cases.yaml            # cases file path
+      environment:                      # include cases with environment
+        customKey: customValue          # define environment key(string) and value(string)
 ```
 
 The test cases are executed in the order of declaration from top to bottom, If the execution fails, and the retry strategy is exceeded, the process is deemed to have failed.
@@ -191,6 +193,28 @@ cases:
      expected: path/to/expected.yaml   # excepted content file path
    - query: echo 'foo'                 # verify by command execute output
      expected: path/to/expected.yaml   # excepted content file path
+```
+
+#### Environment
+
+You could be using `environment` to replace variables from include cases. 
+In the include file, you could declare `${var}` or `$var` to show which environment need to be replaced.
+
+```yaml
+# verify file
+- include:
+    - path/to/include
+  environment:
+    # The key and value only accept string value
+    customKey: customValue  
+
+# include file
+cases:
+  - query: echo "$customKey"
+  
+# Executing verify case, replace environment data
+cases:
+   - query: echo "customValue"
 ```
 
 ## Cleanup

--- a/examples/reusing_cases/e2e.yaml
+++ b/examples/reusing_cases/e2e.yaml
@@ -41,5 +41,7 @@ verify:
   cases:
     - includes:
         - simple-cases.yaml
+      environment:
+        message: "message: OK"
     - query: swctl --display yaml --base-url=http://127.0.0.1:${oap_12800}/graphql service ls
       expected: ../../test/verify/3.expected.yaml

--- a/examples/reusing_cases/simple-cases.yaml
+++ b/examples/reusing_cases/simple-cases.yaml
@@ -18,3 +18,5 @@ cases:
     expected: ../../test/verify/1.expected.yaml
   - actual: ../../test/verify/2.actual.yaml
     expected: ../../test/verify/2.expected.yaml
+  - query: echo "$message"
+    expected: ../../test/verify/include_echo.expected.yaml

--- a/internal/config/e2eConfig.go
+++ b/internal/config/e2eConfig.go
@@ -49,7 +49,7 @@ type Step struct {
 
 type Verify struct {
 	RetryStrategy VerifyRetryStrategy `yaml:"retry"`
-	Cases         []VerifyCase        `yaml:"cases"`
+	Cases         []*VerifyCase       `yaml:"cases"`
 }
 
 func (s *Setup) GetFile() string {
@@ -84,10 +84,11 @@ type Trigger struct {
 }
 
 type VerifyCase struct {
-	Query    string   `yaml:"query"`
-	Actual   string   `yaml:"actual"`
-	Expected string   `yaml:"expected"`
-	Includes []string `yaml:"includes"`
+	Query       string            `yaml:"query"`
+	Actual      string            `yaml:"actual"`
+	Expected    string            `yaml:"expected"`
+	Includes    []string          `yaml:"includes"`
+	Environment map[string]string `yaml:"environment"`
 }
 
 type VerifyRetryStrategy struct {
@@ -96,7 +97,7 @@ type VerifyRetryStrategy struct {
 }
 
 type ReusingCases struct {
-	Cases []VerifyCase `yaml:"cases"`
+	Cases []*VerifyCase `yaml:"cases"`
 }
 
 // GetActual resolves the absolute file path of the actual data file.

--- a/test/verify/include_echo.expected.yaml
+++ b/test/verify/include_echo.expected.yaml
@@ -1,0 +1,18 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+message: OK

--- a/third-party/go/os/env.go
+++ b/third-party/go/os/env.go
@@ -1,0 +1,99 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package os
+
+// Extend env.go, to implement customized ExpandFromSpecificEnv
+
+// ExpandFromSpecificEnv replace ${var} or $var from appoint env, ignore replace if the variable is not exists in env.
+func ExpandFromSpecificEnv(s string, env map[string]string) string {
+	var buf []byte
+	// ${} is all ASCII, so bytes are fine for this operation.
+	i := 0
+	for j := 0; j < len(s); j++ {
+		if s[j] == '$' && j+1 < len(s) {
+			if buf == nil {
+				buf = make([]byte, 0, 2*len(s))
+			}
+			buf = append(buf, s[i:j]...)
+			name, w := getShellName(s[j+1:])
+			if name == "" && w > 0 {
+				// Encountered invalid syntax; keep the content
+				buf = append(buf, s[j:j+w+1]...)
+			} else if name == "" {
+				// Valid syntax, but $ was not followed by a
+				// name. Leave the dollar character untouched.
+				buf = append(buf, s[j])
+			} else {
+				if env[name] != "" {
+					buf = append(buf, env[name]...)
+				} else {
+					// keep the variable
+					buf = append(buf, s[j:j+w+1]...)
+				}
+			}
+			j += w
+			i = j + 1
+		}
+	}
+	if buf == nil {
+		return s
+	}
+	return string(buf) + s[i:]
+}
+
+func getShellName(s string) (string, int) {
+	switch {
+	case s[0] == '{':
+		if len(s) > 2 && isShellSpecialVar(s[1]) && s[2] == '}' {
+			return s[1:2], 3
+		}
+		// Scan to closing brace
+		for i := 1; i < len(s); i++ {
+			if s[i] == '}' {
+				if i == 1 {
+					return "", 2 // Bad syntax; eat "${}"
+				}
+				return s[1:i], i + 1
+			}
+		}
+		return "", 1 // Bad syntax; eat "${"
+	case isShellSpecialVar(s[0]):
+		return s[0:1], 1
+	}
+	// Scan alphanumerics.
+	var i int
+	for i = 0; i < len(s) && isAlphaNum(s[i]); i++ {
+	}
+	return s[:i], i
+}
+
+// isShellSpecialVar reports whether the character identifies a special
+// shell variable such as $*.
+func isShellSpecialVar(c uint8) bool {
+	switch c {
+	case '*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return true
+	}
+	return false
+}
+
+// isAlphaNum reports whether the byte is an ASCII letter, number, or underscore
+func isAlphaNum(c uint8) bool {
+	return c == '_' || '0' <= c && c <= '9' || 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z'
+}

--- a/third-party/go/os/env_test.go
+++ b/third-party/go/os/env_test.go
@@ -1,0 +1,83 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package os
+
+import "testing"
+
+func TestExpandFromSpecificEnv(t *testing.T) {
+	env := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	tests := []struct {
+		name     string
+		content  string
+		excepted string
+	}{
+		{
+			name:     "normal ${var}",
+			content:  "test ${key1} content",
+			excepted: "test value1 content",
+		},
+		{
+			name:     "normal $var",
+			content:  "test $key1 content",
+			excepted: "test value1 content",
+		},
+		{
+			name:     "multiple var",
+			content:  "test $key1 $key2 content",
+			excepted: "test value1 value2 content",
+		},
+		{
+			name:     "not exists ${var}",
+			content:  "test ${not_exists} content",
+			excepted: "test ${not_exists} content",
+		},
+		{
+			name:     "not exists $var",
+			content:  "test $not_exists content",
+			excepted: "test $not_exists content",
+		},
+		{
+			name:     "wrong content",
+			content:  "test ${not_exists content",
+			excepted: "test ${not_exists content",
+		},
+		{
+			name:     "empty ${}",
+			content:  "test ${} content",
+			excepted: "test ${} content",
+		},
+		{
+			name:     "empty $",
+			content:  "test $ content",
+			excepted: "test $ content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expanded := ExpandFromSpecificEnv(tt.content, env)
+			if tt.excepted != expanded {
+				t.Fatalf("except: %s, got: %s", tt.excepted, expanded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We have some similar cases in the main repo, such as verifying the service metrics, they have multiple metrics and services need to be verified. 

So we could use the environment to replace the reuse file content, to help users reduce the cases and help read the cases. 