### PR TITLE
Fix the problem of paring verify.retry.interval without setting value

### DIFF
--- a/commands/verify/verify.go
+++ b/commands/verify/verify.go
@@ -133,6 +133,8 @@ and will be removed in future version, please use Duration style instead, such a
 		if interval, err = time.ParseDuration(itv); err != nil {
 			return 0, err
 		}
+	case nil:
+		interval = 0
 	default:
 		return 0, fmt.Errorf("failed to parse verify.retry.interval: %v", retryInterval)
 	}

--- a/commands/verify/verify_test.go
+++ b/commands/verify/verify_test.go
@@ -54,6 +54,11 @@ func Test_parseInterval(t *testing.T) {
 			name:    "Should fail in other cases",
 			args:    args{retryInterval: "abcdef"},
 			wantErr: true,
+		}, {
+			name:    "Should parse interval without setting value",
+			args:    args{},
+			want:    0,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What this PR dose?

Parse interval without setting value.

### Why we need it?

I have such an E2E testing requirement: we will only need to verify whether it is normal in `setup` phase. When I started  with the following E2E configuration, I encountered an error like below:

**E2E configuration**:

```yaml
setup:
  env: compose
  file: docker-compose.yml
  timeout: 20m

cleanup:
  # always never success failure
  on: always
```

**Partial error log**:

```bash
INFO no trigger need to execute                   
INFO deleting kind cluster...                     
Deleting cluster "kind" ...
INFO delete kind cluster succeeded                
INFO deleting k8s cluster config file:/tmp/e2e-k8s.config 
INFO cleanup part finished successfully           
ERROR failed to parse verify.retry.interval: <nil> 
Error: Process completed with exit code 1.
```



This PR tries to fix this problem of parsing `verify.retry.interval` with nil value. Especially we don't want a verification here.

Although the function `parseInterval` would be removed in `v2.0.0`, this solution could resolve this problem well now.

/kind bug
