### PR TITLE
Expand kind file path with system environment

### DIFF
--- a/internal/config/e2eConfig.go
+++ b/internal/config/e2eConfig.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/apache/skywalking-infra-e2e/internal/constant"
@@ -90,7 +91,10 @@ type Verify struct {
 }
 
 func (s *Setup) GetFile() string {
-	return util.ResolveAbs(s.File)
+	// expand the file path with system environment
+	file := os.ExpandEnv(s.File)
+	file = util.ResolveAbs(file)
+	return file
 }
 
 type Manifest struct {

--- a/internal/config/e2eConfig_test.go
+++ b/internal/config/e2eConfig_test.go
@@ -1,0 +1,79 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/apache/skywalking-infra-e2e/internal/util"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestSetup_GetFile(t *testing.T) {
+	randomVersion := rand.String(10)
+	type fields struct {
+		File string
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		beforeEach func()
+		want       string
+	}{{
+		name: "Should keep file path still",
+		fields: fields{
+			File: "fake/file/path.yaml",
+		},
+		want: util.ResolveAbs("fake/file/path.yaml"),
+	}, {
+		name: "Should expand file path",
+		fields: fields{
+			File: "kind/$VERSION.yaml",
+		},
+		beforeEach: func() {
+			os.Clearenv()
+			os.Setenv("VERSION", randomVersion)
+		},
+		want: util.ResolveAbs("kind/" + randomVersion + ".yaml"),
+	}, {
+		name: "Should never expand file path",
+		fields: fields{
+			File: "kind/$VERSION.yaml",
+		},
+		beforeEach: func() {
+			os.Clearenv()
+			os.Setenv("INVAD_VERSION", randomVersion)
+		},
+		want: util.ResolveAbs("kind/.yaml"),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.beforeEach != nil {
+				tt.beforeEach()
+			}
+			s := &Setup{
+				File: tt.fields.File,
+			}
+			if got := s.GetFile(); got != tt.want {
+				t.Errorf("Setup.GetFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR dose?

Expand kind file path with system environment.

I have tested manually for this feature, please see more details about E2E configuration in [here](https://github.com/JohnNiang/ks-devops/blob/d0c330ac8a3e8022cf7856d658e027d4732e0374/.github/workflows/e2e.install.yaml#L18-L32).

Please checkout the result in [here](https://github.com/JohnNiang/ks-devops/runs/4153819572?check_suite_focus=true).

### Why we need it?

Please see https://github.com/apache/skywalking/issues/8100.

### Which issue dose this PR fix?

Fix https://github.com/apache/skywalking/issues/8100

/kind feature