### PR TITLE
Fix parsing error

### DIFF
--- a/internal/components/verifier/funcs.go
+++ b/internal/components/verifier/funcs.go
@@ -65,7 +65,8 @@ func regexpMatch(s, pattern string) string {
 		return fmt.Sprintf(`<%q>`, err)
 	}
 	if !matched {
-		return fmt.Sprintf("<%q does not match the pattern %q>", s, pattern)
+		// Note: Changing %s to %q for s would throw yaml parsing error 
+		return fmt.Sprintf("<%s does not match the pattern %q>", s, pattern)
 	}
 	return s
 }

--- a/internal/components/verifier/funcs.go
+++ b/internal/components/verifier/funcs.go
@@ -65,7 +65,7 @@ func regexpMatch(s, pattern string) string {
 		return fmt.Sprintf(`<%q>`, err)
 	}
 	if !matched {
-		// Note: Changing %s to %q for s would throw yaml parsing error 
+		// Note: Changing %s to %q for s would throw yaml parsing error
 		return fmt.Sprintf("<%s does not match the pattern %q>", s, pattern)
 	}
 	return s


### PR DESCRIPTION
Using `%q` to format the actual data causes e2e tests to fail, so for now reverting to a working state.