### PR TITLE
Support `SHA256` and `SHA512` in verify case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,24 +2,15 @@ Changes by Version
 ==================
 Release Notes.
 
-1.2.0
+1.3.0
 ------------------
 #### Features
-* Expand kind file path with system environment.
-* Support shutdown service during setup phase in compose mode.
-* Expand kind file path with system environment. 
-* Support arbitrary os and arch.
-* Support `docker-compose` v2 container naming.
-* Support installing via `go install` and add install doc.
-* Add retry when delete kind cluster.
-* Upgrade to go1.18.
+* Support `sha256enc` and `sha512enc` encoding in verify case.
 
 #### Bug Fixes
-* Fix the problem of parsing `verify.retry.interval` without setting value.
 
 #### Documentation
-* Make `trigger.times` parameter doc more clear.
 
 #### Issues and PR
-- All issues are [here](https://github.com/apache/skywalking/milestone/111?closed=1)
-- All and pull requests are [here](https://github.com/apache/skywalking-infra-e2e/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.2.0)
+- All issues are [here](https://github.com/apache/skywalking/milestone/148?closed=1)
+- All and pull requests are [here](https://github.com/apache/skywalking-infra-e2e/milestone/4?closed=1)

--- a/changes/changes-1.2.0.md
+++ b/changes/changes-1.2.0.md
@@ -1,0 +1,25 @@
+Changes by Version
+==================
+Release Notes.
+
+1.2.0
+------------------
+#### Features
+* Expand kind file path with system environment.
+* Support shutdown service during setup phase in compose mode.
+* Expand kind file path with system environment. 
+* Support arbitrary os and arch.
+* Support `docker-compose` v2 container naming.
+* Support installing via `go install` and add install doc.
+* Add retry when delete kind cluster.
+* Upgrade to go1.18.
+
+#### Bug Fixes
+* Fix the problem of parsing `verify.retry.interval` without setting value.
+
+#### Documentation
+* Make `trigger.times` parameter doc more clear.
+
+#### Issues and PR
+- All issues are [here](https://github.com/apache/skywalking/milestone/111?closed=1)
+- All and pull requests are [here](https://github.com/apache/skywalking-infra-e2e/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.2.0)

--- a/docs/en/setup/Configuration-File.md
+++ b/docs/en/setup/Configuration-File.md
@@ -228,6 +228,8 @@ In order to make the program easier for users to read and use, some code convers
 |Function|Description|Grammar|Result|
 |-------|------------|-------|------|
 |b64enc|Base64 encode|{{ b64enc "Foo" }}|Zm9v|
+|sha256enc|Sha256 encode|{{ sha256enc "Foo" }}|1cbec737f863e4922cee63cc2ebbfaafcd1cff8b790d8cfd2e6a5d550b648afa|
+|sha512enc|Sha512 encode|{{ sha512enc "Foo" }}|4abcd2639957cb23e33f63d70659b602a5923fafcfd2768ef79b0badea637e5c837161aa101a557a1d4deacbd912189e2bb11bf3c0c0c70ef7797217da7e8207|
 
 ### Reuse cases
 

--- a/internal/components/verifier/funcs.go
+++ b/internal/components/verifier/funcs.go
@@ -18,7 +18,10 @@
 package verifier
 
 import (
+	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strings"
@@ -42,7 +45,9 @@ var customFuncMap = map[string]any{
 	"notEmpty": notEmpty,
 
 	// Encoding:
-	"b64enc": base64encode,
+	"b64enc":    base64encode,
+	"sha256enc": sha256encode,
+	"sha512enc": sha512encode,
 
 	// Regex:
 	"regexp": regexpMatch,
@@ -50,6 +55,18 @@ var customFuncMap = map[string]any{
 
 func base64encode(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func sha256encode(s string) string {
+	hash := sha256.New()
+	hash.Write([]byte(s))
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sha512encode(s string) string {
+	hash := sha512.New()
+	hash.Write([]byte(s))
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func notEmpty(s string) string {


### PR DESCRIPTION
I am currently adding the process topology to the E2E testing, but since SHA256 generates the process ID value, this method needs to be added for verification cases.
Also, 1.2.0 of the infra-e2e was released, so I updated the change log. 