### PR TITLE
Ignore cancel error when copying container logs

### DIFF
--- a/internal/components/setup/compose.go
+++ b/internal/components/setup/compose.go
@@ -20,6 +20,7 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -226,7 +227,7 @@ func exposeComposeLog(cli *client.Client, service *ComposeService, containerID s
 
 	go func() {
 		defer writer.Close()
-		if _, err := stdcopy.StdCopy(writer, writer, logs); err != nil {
+		if _, err := stdcopy.StdCopy(writer, writer, logs); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Log.Warnf("write %s std log error: %v", service.Name, err)
 		}
 	}()


### PR DESCRIPTION
This tool always prints the following warning logs when finishing the tests, this is unnecessary because the context is cancelled as expected.

<img width="853" alt="image" src="https://user-images.githubusercontent.com/15965696/198581834-934b3d64-0e4c-4a71-8941-363b6fa99be3.png">
