### PR TITLE
Disable batch mode by default, add it to GHA and enable by default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,10 @@ inputs:
   log-dir:
     description: The container logs directory
     required: false
+  batch-mode:
+    description: Whether to run in batch mode, all interactive operations are disabled
+    required: false
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -98,5 +102,6 @@ runs:
       run: |
         e2e run \
           -c "${{ inputs.e2e-file }}" \
+          --batch-mode "${{ inputs.batch-mode }}" \
           -w "${{ steps.e2e-dir-generator.outputs.work }}" \
           -l "${{ steps.e2e-dir-generator.outputs.log-case }}"

--- a/commands/root.go
+++ b/commands/root.go
@@ -93,8 +93,9 @@ func Execute() error {
 	Root.PersistentFlags().StringVarP(&util.WorkDir, "work-dir", "w", "~/.skywalking-infra-e2e", "the working directory for skywalking-infra-e2e")
 	Root.PersistentFlags().StringVarP(&util.LogDir, "log-dir", "l", "~/.skywalking-infra-e2e/logs", "the container logs directory for environment")
 	Root.PersistentFlags().StringVarP(&util.CfgFile, "config", "c", constant.E2EDefaultFile, "the config file")
-	Root.PersistentFlags().BoolVarP(&util.BatchMode, "batch-mode", "B", true,
-		"whether to output in batch mode, if false, the output will be printed in real time. This option is not valid in concurrency mode.")
+	Root.PersistentFlags().BoolVarP(&util.BatchMode, "batch-mode", "B", false,
+		`whether to run in batch mode, if true, all interactive operations are disabled, including real-time progress bar.
+This option is always enabled in concurrency mode and in our GitHub Actions.`)
 
 	return Root.Execute()
 }


### PR DESCRIPTION
We should disable batch mode by default when running locally, and enable it by default when running in CI.

Also add it to our `action.yaml` so we can change the value, like in https://github.com/apache/skywalking-python/pull/251