### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check License
         uses: apache/skywalking-eyes@ec88b7d850018c8983f87729ea88549e100c5c82

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go 1.18
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
     - if: runner.os == 'Linux'


### PR DESCRIPTION
The following warning is due to setup-go@v2
<html>
<body>
<!--StartFragment-->

 
--
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-go@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.Show more
 

<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>