### PR TITLE
Leverage the built-in cache in setup-go@v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,30 +35,7 @@ runs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.18
-    - if: runner.os == 'Linux'
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: skywalking-infra-e2e-${{ runner.os }}-go-${{ hashFiles(format('{0}/{1}', github.action_path, 'go.sum')) }}
-        restore-keys: skywalking-infra-e2e-${{ runner.os }}-go-
-    - if: runner.os == 'macOS'
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/Library/Caches/go-build
-          ~/go/pkg/mod
-        key: skywalking-infra-e2e-${{ runner.os }}-go-${{ hashFiles(format('{0}/{1}', github.action_path, 'go.sum')) }}
-        restore-keys: skywalking-infra-e2e-${{ runner.os }}-go-
-    - if: runner.os == 'Windows'
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~\AppData\Local\go-build
-          ~\go\pkg\mod
-        key: skywalking-infra-e2e-${{ runner.os }}-go-${{ hashFiles(format('{0}/{1}', github.action_path, 'go.sum')) }}
-        restore-keys: skywalking-infra-e2e-${{ runner.os }}-go-
+        cache-dependency-path: ${{ github.action_path }}/go.sum
     - shell: bash
       run: make -C $GITHUB_ACTION_PATH install DESTDIR=/usr/local/bin
     - name: E2E Dir Generator


### PR DESCRIPTION
setup-go@v4 supports caching by default, this patch removes the explicit caching setup and use the default one

https://github.com/actions/setup-go#v4