### PR TITLE
Chore: make linter happy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,11 +36,6 @@ linters-settings:
   goconst:
     min-len: 2
     min-occurrences: 2
-  depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-messages:
-      fmt: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
     ignore-words:
@@ -98,7 +93,6 @@ linters-settings:
 linters:
   enable:
     - deadcode
-    - depguard
     - dogsled
     - dupl
     - errcheck
@@ -115,7 +109,6 @@ linters:
     - ineffassign
     - lll
     - misspell
-    - nakedret
     - staticcheck
     - stylecheck
     - typecheck
@@ -125,6 +118,8 @@ linters:
     - whitespace
   disable:
     - structcheck
+    - depguard
+    - nakedret
 
 service:
   golangci-lint-version: 1.20.x

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ all: clean lint test build
 
 .PHONY: lint
 lint:
-	$(GO_LINT) version || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin -d "v1.46.2"
+	$(GO_LINT) version || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin -d "v1.55.2"
 	$(GO_LINT) run -v --timeout 5m ./...
 
 .PHONY: fix-lint

--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
+
 package main
 
 import (

--- a/commands/cleanup/cleanup.go
+++ b/commands/cleanup/cleanup.go
@@ -1,4 +1,3 @@
-//
 // Licensed to Apache Software Foundation (ASF) under one or more contributor
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
@@ -15,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package cleanup
 
 import (

--- a/commands/root.go
+++ b/commands/root.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
+
 package commands
 
 import (

--- a/commands/run/run.go
+++ b/commands/run/run.go
@@ -1,4 +1,3 @@
-//
 // Licensed to Apache Software Foundation (ASF) under one or more contributor
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
@@ -15,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package run
 
 import (

--- a/commands/trigger/trigger.go
+++ b/commands/trigger/trigger.go
@@ -1,4 +1,3 @@
-//
 // Licensed to Apache Software Foundation (ASF) under one or more contributor
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
@@ -15,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package trigger
 
 import (

--- a/commands/version.go
+++ b/commands/version.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
+
 package commands
 
 var version string

--- a/internal/components/trigger/http.go
+++ b/internal/components/trigger/http.go
@@ -15,6 +15,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package trigger
 
 import (

--- a/internal/components/verifier/funcs.go
+++ b/internal/components/verifier/funcs.go
@@ -31,7 +31,7 @@ import (
 
 // funcMap produces the custom function map.
 // Use this to pass the functions into the template engine:
-// 	tpl := template.New("foo").Funcs(funcMap()))
+// tpl := template.New("foo").Funcs(funcMap()))
 func funcMap() template.FuncMap {
 	fm := make(map[string]any, len(customFuncMap))
 	for k, v := range customFuncMap {

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
+
 package logger
 
 import (


### PR DESCRIPTION
When I ran `make release`, I got weird errors from golangci-lint with go 1.21.