### PR TITLE
Adding `setup.kind.no-wait` configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Release Notes.
 
 1.4.0
 ------------------
+#### Features
+
+* Adding `setup.kind.no-wait` to support should wait for the kind cluster to be ready or not.
+
 #### Bug Fixes
 
 * Fix kind load docker-image error

--- a/docs/en/setup/Configuration-File.md
+++ b/docs/en/setup/Configuration-File.md
@@ -39,6 +39,7 @@ setup:
           label-selector:               # The resource label selector
           for:                          # The wait condition
   kind:
+     no-wait: false                     # Should wait the kind cluster resource ready, default is false, means wait for the cluster to be ready, otherwise it would not wait.
      import-images:                     # import docker images to KinD
         - image:version                 # support using env to expand image, such as `${env_key}` or `$env_key`
      expose-ports:                      # Expose resource for host access

--- a/internal/components/setup/kind.go
+++ b/internal/components/setup/kind.go
@@ -285,7 +285,9 @@ func createKindCluster(kindConfigPath string, e2eConfig *config.E2EConfig) error
 		"create", "cluster",
 		"--config", kindConfigPath,
 		"--kubeconfig", kubeConfigPath,
-		"--wait", e2eConfig.Setup.GetTimeout().String(),
+	}
+	if !e2eConfig.Setup.Kind.NoWait {
+		args = append(args, "--wait", e2eConfig.Setup.GetTimeout().String())
 	}
 
 	logger.Log.Info("creating kind cluster...")

--- a/internal/config/e2eConfig.go
+++ b/internal/config/e2eConfig.go
@@ -78,6 +78,7 @@ type Step struct {
 type KindSetup struct {
 	ImportImages []string         `yaml:"import-images"`
 	ExposePorts  []KindExposePort `yaml:"expose-ports"`
+	NoWait       bool             `yaml:"no-wait"`
 }
 
 type KindExposePort struct {


### PR DESCRIPTION
Currently, I am trying to use the E2E tool for simulating a cilium cluster (based on kind), but since cilium requires to use them self CNI, so all kind resources will not be deployed (in padding state) until cilium is installed. Therefore the wait in the setup stage has no meaning.

To fix this issue, I added a `no-wait` field with default value as `false`,  it still continues to wait unless specified manually as `true` in the configuration. Thus it won't affect existing E2E workflow.