### PR TITLE
Install docker-compose if absent

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -5,9 +5,9 @@
 # the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,7 +32,6 @@ jobs:
     name: E2E Test
     runs-on: ubuntu-latest
     steps:
-            
       - name: Set up Go 1.18
         uses: actions/setup-go@v4
         with:
@@ -45,10 +44,16 @@ jobs:
       - name: Build e2e
         run: make linux
 
+      - name: Install docker-compose
+        shell: bash
+        run: |
+          if ! command docker-compose 2>&1 > /dev/null; then
+            echo "Installing docker-compose"
+            sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+          fi
+
       - name: Run E2E Test
         uses: apache/skywalking-infra-e2e@main
         with:
-           e2e-file: ./test/e2e/e2e.yaml
-
-              
-       
+          e2e-file: ./test/e2e/e2e.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -27,10 +27,19 @@ inputs:
   batch-mode:
     description: Whether to run in batch mode, all interactive operations are disabled
     required: false
-    default: 'true'
+    default: "true"
 runs:
   using: "composite"
   steps:
+    - name: Install docker-compose
+      shell: bash
+      if: runner.os != 'Windows'
+      run: |
+        if ! command docker-compose 2>&1 > /dev/null; then
+          echo "Installing docker-compose"
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+        fi
     - name: Set up Go 1.18
       uses: actions/setup-go@v4
       with:
@@ -39,7 +48,7 @@ runs:
     - shell: bash
       run: make -C $GITHUB_ACTION_PATH install DESTDIR=/usr/local/bin
     - name: E2E Dir Generator
-      id: 'e2e-dir-generator'
+      id: "e2e-dir-generator"
       shell: bash
       run: |
         WORK_DIR="${{ runner.temp }}/skywalking-infra-e2e"


### PR DESCRIPTION
GHA ubuntu-latest has removed docker-compose, before we can adopt the `docker compose` this is the fastest way to workaround the missing command `docker-compose` error:


```
ERROR cleanup part error: Local Docker Compose not found. Is docker-compose on the PATH? 
```