### PR TITLE
Stop the trigger when reach to the maximum retry count

### DIFF
--- a/internal/components/trigger/http.go
+++ b/internal/components/trigger/http.go
@@ -86,6 +86,10 @@ func (h *httpAction) Do() chan error {
 					result <- err
 					sent = true
 				}
+				if h.times == h.executedCount {
+					t.Stop()
+					return
+				}
 			case <-h.stopCh:
 				t.Stop()
 				result <- nil


### PR DESCRIPTION
When I was testing the alarm recovery case for the linked issue(https://github.com/apache/skywalking/issues/13492) , the e2e test did not stop the HTTP action at the expected times defined in e2e.yaml. Currently, it continues running until the entire test ends.
