### PR TITLE
chore: upgrade Go from 1.24 to 1.26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.26
           cache-dependency-path: |
             go.sum
         id: go

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.26
           cache-dependency-path: |
             go.sum
         id: go

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-FROM golang:1.24 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /e2e
 
@@ -24,7 +24,7 @@ COPY . .
 
 RUN make linux
 
-FROM golang:1.24 AS bin
+FROM golang:1.26 AS bin
 
 COPY --from=build /e2e/bin/linux/e2e /usr/local/bin/e2e
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ all: clean lint test build
 
 .PHONY: lint
 lint:
-	$(GO_LINT) version || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin -d "v2.1.6"
+	$(GO_LINT) version || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin -d "v2.11.4"
 	$(GO_LINT) run -v ./...
 
 .PHONY: fix-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-infra-e2e
 
-go 1.24
+go 1.26
 
 require (
 	github.com/docker/docker v20.10.7+incompatible


### PR DESCRIPTION
## Summary

- Upgrade Go version from 1.24 to 1.26 as 1.24 is reaching end of life
- Update `go.mod`, `.github/workflows/build.yaml`, and `.github/workflows/e2e-test.yaml`

## Test plan

- [x] All unit tests pass locally with Go 1.26
- [ ] CI build and e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)