### PR TITLE
feat: add noDuplicates pipe function for duplicate data verification

### DIFF
--- a/docs/en/setup/Configuration-File.md
+++ b/docs/en/setup/Configuration-File.md
@@ -248,6 +248,19 @@ For example, if a generic expected entry (e.g., `notEmpty`) appears before a spe
 {{- end }}
 ```
 
+##### Duplicate Detection
+
+`noDuplicates` is a pipe function that verifies a list contains no duplicate items. Two items are considered duplicates when all their fields are equal. It can be combined with `contains`, `containsOnce`, or `range`.
+
+```yaml
+{{- contains (.metrics | noDuplicates) }}
+- name: {{ notEmpty .name }}
+  value: {{ notEmpty .value }}
+{{- end }}
+```
+
+When duplicates exist in the actual data, verification will fail with an error indicating the duplicated item.
+
 ##### Encoding
 
 In order to make the program easier for users to read and use, some code conversions are provided.

--- a/internal/components/verifier/funcs.go
+++ b/internal/components/verifier/funcs.go
@@ -54,6 +54,9 @@ var customFuncMap = map[string]any{
 
 	// Calculation:
 	"subtractor": subtractor,
+
+	// List:
+	"noDuplicates": noDuplicates,
 }
 
 func base64encode(s string) string {
@@ -102,4 +105,19 @@ func subtractor(total int, nums ...int) int {
 		total -= num
 	}
 	return total
+}
+
+func noDuplicates(list any) any {
+	items, ok := list.([]any)
+	if !ok {
+		return list
+	}
+	for i := 0; i < len(items); i++ {
+		for j := i + 1; j < len(items); j++ {
+			if fmt.Sprint(items[i]) == fmt.Sprint(items[j]) {
+				return fmt.Sprintf("<duplicate found: %v>", items[i])
+			}
+		}
+	}
+	return list
 }

--- a/internal/components/verifier/verifier_test.go
+++ b/internal/components/verifier/verifier_test.go
@@ -502,6 +502,83 @@ metrics:
 			wantErr: true, // service-A does not exist in actual
 		},
 		{
+			name: "noDuplicates should pass when list has no duplicates",
+			args: args{
+				actualData: `
+metrics:
+  - name: service-A
+    value: "100"
+  - name: service-B
+    value: "200"
+`,
+				expectedTemplate: `
+metrics:
+{{- contains (.metrics | noDuplicates) }}
+  - name: {{ notEmpty .name }}
+    value: {{ notEmpty .value }}
+{{- end }}
+`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "noDuplicates should fail when list has duplicate items",
+			args: args{
+				actualData: `
+metrics:
+  - name: service-A
+    value: "100"
+  - name: service-A
+    value: "100"
+`,
+				expectedTemplate: `
+metrics:
+{{- contains (.metrics | noDuplicates) }}
+  - name: {{ notEmpty .name }}
+    value: {{ notEmpty .value }}
+{{- end }}
+`,
+			},
+			wantErr: true, // duplicate entry exists
+		},
+		{
+			name: "noDuplicates should work with containsOnce",
+			args: args{
+				actualData: `
+- name: service-A
+  value: "100"
+- name: service-B
+  value: "200"
+- name: service-A
+  value: "100"
+`,
+				expectedTemplate: `
+{{- containsOnce (. | noDuplicates) }}
+- name: {{ notEmpty .name }}
+  value: {{ notEmpty .value }}
+{{- end }}
+`,
+			},
+			wantErr: true, // duplicate entry exists even though containsOnce would pass
+		},
+		{
+			name: "noDuplicates should pass with range and no duplicates",
+			args: args{
+				actualData: `
+metrics:
+  - name: service-A
+  - name: service-B
+`,
+				expectedTemplate: `
+metrics:
+{{- range (.metrics | noDuplicates) }}
+  - name: {{ notEmpty .name }}
+{{- end }}
+`,
+			},
+			wantErr: false,
+		},
+		{
 			name: "notEmpty with nil",
 			args: args{
 				actualData: `


### PR DESCRIPTION
## Summary

- Add `noDuplicates` template pipe function that verifies a list has no duplicate entries (full deep equality check)
- Works with `contains`, `containsOnce`, and `range` via standard Go template pipe syntax: `(.metrics | noDuplicates)`
- Resolves apache/skywalking#12253

## Usage

```yaml
{{- contains (.metrics | noDuplicates) }}
- name: {{ notEmpty .name }}
  value: {{ notEmpty .value }}
{{- end }}
```

When duplicates exist in actual data, verification fails with an error indicating the duplicated item.

## Changes

| File | Change |
|------|--------|
| `internal/components/verifier/funcs.go` | Add `noDuplicates` function |
| `internal/components/verifier/verifier_test.go` | 4 test cases |
| `docs/en/setup/Configuration-File.md` | Document `noDuplicates` |

## Test plan

- [x] All existing tests pass (no regression)
- [x] `noDuplicates` passes when list has no duplicates (with `contains`)
- [x] `noDuplicates` fails when list has duplicate items (with `contains`)
- [x] `noDuplicates` fails with duplicates when used with `containsOnce`
- [x] `noDuplicates` passes with `range` and no duplicates
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)