### PR TITLE
fix: disable Ryuk reaper when cleanup.on is never

### DIFF
--- a/internal/components/setup/compose.go
+++ b/internal/components/setup/compose.go
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/apache/skywalking-infra-e2e/internal/config"
+	"github.com/apache/skywalking-infra-e2e/internal/constant"
 	"github.com/apache/skywalking-infra-e2e/internal/logger"
 	"github.com/apache/skywalking-infra-e2e/internal/util"
 )
@@ -53,6 +54,13 @@ func ComposeSetup(e2eConfig *config.E2EConfig) error {
 	if e2eConfig.Setup.InitSystemEnvironment != "" {
 		profilePath := util.ResolveAbs(e2eConfig.Setup.InitSystemEnvironment)
 		util.ExportEnvVars(profilePath)
+	}
+
+	// Disable Ryuk reaper when cleanup.on is "never" so containers survive process exit.
+	if e2eConfig.Cleanup.On == constant.CleanUpNever {
+		if err := os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true"); err != nil {
+			return fmt.Errorf("failed to disable Ryuk reaper: %v", err)
+		}
 	}
 
 	// create compose stack


### PR DESCRIPTION
## Summary

- After migrating to testcontainers-go (#146), the Ryuk reaper sidecar automatically removes all containers when the e2e process exits, making `cleanup.on: never` ineffective in compose mode
- Fix: disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true` before creating the compose stack when `cleanup.on` is configured as `never`

## Test plan

- [x] Verified locally with a Docker Compose e2e config using `cleanup.on: never` — containers now survive after process exit
- [x] Verified Ryuk is no longer started when `cleanup.on: never`
- [x] Lint and unit tests pass (`make lint && make test`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)