### PR TITLE
Use Docker Compose v2 (`docker compose`) in the compose log collector

### DIFF
--- a/internal/constant/compose.go
+++ b/internal/constant/compose.go
@@ -20,5 +20,5 @@ package constant
 
 const (
 	Compose        = "compose"
-	ComposeCommand = "docker-compose"
+	ComposeCommand = "docker compose"
 )

--- a/test/e2e/collect-expected.yaml
+++ b/test/e2e/collect-expected.yaml
@@ -1,0 +1,1 @@
+collected: "true"

--- a/test/e2e/collect-expected.yaml
+++ b/test/e2e/collect-expected.yaml
@@ -1,1 +1,18 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 collected: "true"

--- a/test/e2e/e2e.yaml
+++ b/test/e2e/e2e.yaml
@@ -24,6 +24,17 @@ setup:
 cleanup:
   # always never success failure
   on: always
+  # Exercise the compose log collector in CI so a regression to Docker Compose v1 is
+  # caught: GitHub-hosted runners ship only Compose v2, so the collector must use
+  # `docker compose`. Auto-collect is off here; the verify case below invokes
+  # `e2e collect` explicitly and asserts a file was collected.
+  collect:
+    on: never
+    output-dir: /tmp/e2e-collect-check
+    items:
+      - service: httpbin
+        paths:
+          - /etc/hostname
 
 verify:
   # verify with retry strategy
@@ -55,4 +66,14 @@ verify:
     - name: currency & non-fail-fast mode
       query: './bin/linux/e2e verify -c  ./test/e2e/concurrency/non-fail-fast/internal/verify.yaml --summary-only -o yaml'
       expected: ./concurrency/non-fail-fast/expected.yaml
+
+    # Guards the compose log collector against a regression to Docker Compose v1
+    # (which is absent on GitHub-hosted runners). Runs `e2e collect` against the
+    # already-running compose stack and asserts a container file was collected.
+    - name: compose log collector works on Docker Compose v2
+      query: |
+        rm -rf /tmp/e2e-collect-check
+        ./bin/linux/e2e collect -c ./test/e2e/e2e.yaml > /dev/null 2>&1 || true
+        if [ -s /tmp/e2e-collect-check/httpbin/etc/hostname ]; then echo 'collected: "true"'; else echo 'collected: "false"'; fi
+      expected: ./collect-expected.yaml
 


### PR DESCRIPTION
### Fix `docker-compose: command not found` in the compose log collector on modern runners

#### Why now
GitHub **deprecated and removed Docker Compose v1** (the standalone `docker-compose` binary) from its hosted Ubuntu runner images — see the [deprecation notice](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/) and [actions/runner-images#9692](https://github.com/actions/runner-images/issues/9692). Current `ubuntu-latest` / `ubuntu-24.04` images ship **only Docker Compose v2** (`docker compose`); `docker-compose` is gone ([actions/runner-images#9864](https://github.com/actions/runner-images/issues/9864)). So any workflow on those images hits this in the collector:
```
docker compose ps failed: … stderr: docker-compose: command not found
```
(observed in Apache SkyWalking's e2e — container logs were never collected on failures, making CI failures much harder to debug).

#### Problem
`setup` already uses Compose v2 (via `testcontainers-go/modules/compose`); only the **log collector** still shelled out to v1. `internal/constant/compose.go` defines `ComposeCommand = "docker-compose"`, used by `collector.findComposeContainer` → `docker-compose -f … -p … ps -q …`. It's the only `docker-compose` reference in the repo, and it's executed via `bash -ec`.

#### Fix
```diff
-	ComposeCommand = "docker-compose"
+	ComposeCommand = "docker compose"
```
Run via `bash -ec`, the two-word v2-plugin invocation works as-is, and v2 accepts the same `-f / -p / ps -q` flags.

#### CI coverage (why this wasn't caught — now fixed)
infra-e2e's own e2e (`test/e2e/e2e.yaml`) **runs on `ubuntu-latest`** (no v1) but never exercised the collector — so it neither caught the breakage nor would validate this fix. This PR adds a `cleanup.collect` config + a verify case that runs `e2e collect` against the running stack and **asserts a container file was gathered**. The collector now runs in CI on a v1-less runner — proving it works via `docker compose` v2 and **failing the build if it ever regresses to v1**.

#### Validation (local)
A compose e2e (`nginx`) and the new httpbin guard, built binary, run with:
- `docker-compose` v1 hidden, and a failing `docker-compose` **stub shadowing PATH**;

→ `e2e run` / `e2e collect` complete green and the collector gathers `inspect.json` + a container file via `docker compose` v2, while the stub is **never invoked**. The new verify case reports `1 passed`.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. N/A